### PR TITLE
Implement mouse-driven hero particle effect

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -11,15 +11,27 @@
 }
 
 .problem-line {
+    --offset: -40px;
     opacity: 0;
-    transform: translateY(20px);
-    transition: opacity 0.8s ease, transform 0.8s ease;
+    transform: translateX(var(--offset)) scale(0.95);
+    filter: blur(4px);
     margin-bottom: 20px;
 }
 
+.problem-line:nth-child(even) {
+    --offset: 40px;
+}
+
 .problem-line.show {
-    opacity: 1;
-    transform: translateY(0);
+    animation: problemLineIn 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes problemLineIn {
+    to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+        filter: blur(0);
+    }
 }
 
 .problem-line.highlight {

--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,14 @@
     </header>
     <main>
     <!-- Hero bleibt ganz oben -->
+        <section id="hero" class="hero-section">
+            <canvas id="hero-canvas"></canvas>
+            <div class="container">
+                <h1>Planbarer KI Erfolg statt teurer Experimente</h1>
+                <p class="subtitle">Wir konzipieren KI Projekte mit strategischer Weitsicht, technischer Machbarkeit und rechtlicher Sicherheit, damit aus Ideen Investitionen werden, die sich lohnen.</p>
+                <a href="https://calendly.com/aiconsulting-jx7n/30min" target="_blank" class="cta-button">Jetzt kostenlose Potenzial-Analyse buchen</a>
+            </div>
+        </section>
         <!-- Problem-Abschnitt -->
         <section id="problem" class="problem-section">
             <div class="problem-line">Fachkräfte? Kaum zu finden – und schwer zu halten.</div>
@@ -51,14 +59,6 @@
             <div class="problem-line">Mit intelligenten, DSGVO-konformen Automatisierungen.</div>
         </section>
         <!-- Ende Problem-Abschnitt -->
-        <section id="hero" class="hero-section">
-            <canvas id="hero-canvas"></canvas>
-            <div class="container">
-                <h1>Planbarer KI Erfolg statt teurer Experimente</h1>
-                <p class="subtitle">Wir konzipieren KI Projekte mit strategischer Weitsicht, technischer Machbarkeit und rechtlicher Sicherheit, damit aus Ideen Investitionen werden, die sich lohnen.</p>
-                <a href="https://calendly.com/aiconsulting-jx7n/30min" target="_blank" class="cta-button">Jetzt kostenlose Potenzial-Analyse buchen</a>
-            </div>
-        </section>
         <section id="services" class="services-section">
             <div class="container">
                 <h2>Ihre Abkürzung zu funktionierenden KI-Lösungen</h2>
@@ -122,98 +122,21 @@
     <script>
     document.addEventListener("DOMContentLoaded", () => {
         const lines = document.querySelectorAll(".problem-line");
+        lines.forEach((line, i) => line.style.animationDelay = `${i * 0.15}s`);
         const observer = new IntersectionObserver((entries) => {
-            entries.forEach((entry, index) => {
+            entries.forEach((entry) => {
                 if (entry.isIntersecting) {
-                    setTimeout(() => {
-                        entry.target.classList.add("show");
-                    }, index * 200);
+                    entry.target.classList.add("show");
                     observer.unobserve(entry.target);
                 }
             });
-        }, { threshold: 0.3 });
+        }, { threshold: 0.2 });
 
         lines.forEach(line => observer.observe(line));
     });
     </script>
-    <script>
-        const heroCanvas = document.getElementById('hero-canvas');
-        if (heroCanvas) {
-            const heroCtx = heroCanvas.getContext('2d');
-            heroCanvas.width = heroCanvas.parentElement.offsetWidth;
-            heroCanvas.height = heroCanvas.parentElement.offsetHeight;
-            let heroNodes = [];
-            const heroNumNodes = 100;
-            const heroConnectionDistance = 220;
-            const heroMouse = { x: undefined, y: undefined, radius: 150 };
-            window.addEventListener('mousemove', (event) => {
-                const rect = heroCanvas.getBoundingClientRect();
-                heroMouse.x = event.clientX - rect.left;
-                heroMouse.y = event.clientY - rect.top;
-            });
-            window.addEventListener('mouseout', () => {
-                heroMouse.x = undefined;
-                heroMouse.y = undefined;
-            });
-            class HeroNode {
-                constructor(x, y) { this.x = x; this.y = y; this.size = Math.random() * 2.5 + 1.5; this.baseX = this.x; this.baseY = this.y; this.density = (Math.random() * 40) + 5; }
-                draw() { heroCtx.fillStyle = 'rgba(139, 174, 255, 0.8)'; heroCtx.beginPath(); heroCtx.arc(this.x, this.y, this.size, 0, Math.PI * 2); heroCtx.closePath(); heroCtx.fill(); }
-                update() {
-                    let dx = heroMouse.x - this.x; let dy = heroMouse.y - this.y;
-                    let distance = Math.sqrt(dx * dx + dy * dy);
-                    if (distance < heroMouse.radius) {
-                        let force = (heroMouse.radius - distance) / heroMouse.radius;
-                        this.x -= (dx / distance) * force * this.density;
-                        this.y -= (dy / distance) * force * this.density;
-                    } else {
-                        if (this.x !== this.baseX) { this.x -= (this.x - this.baseX) / 20; }
-                        if (this.y !== this.baseY) { this.y -= (this.y - this.baseY) / 20; }
-                    }
-                }
-            }
-            function heroInit() {
-                heroNodes = [];
-                for (let i = 0; i < heroNumNodes; i++) {
-                    heroNodes.push(new HeroNode(Math.random() * heroCanvas.width, Math.random() * heroCanvas.height));
-                }
-            }
-            function heroAnimate() {
-                heroCtx.clearRect(0, 0, heroCanvas.width, heroCanvas.height);
-                for (let i = 0; i < heroNodes.length; i++) {
-                    heroNodes[i].update(); heroNodes[i].draw();
-                }
-                heroConnect();
-                requestAnimationFrame(heroAnimate);
-            }
-            function heroConnect() {
-                for (let a = 0; a < heroNodes.length; a++) {
-                    for (let b = a; b < heroNodes.length; b++) {
-                        let distance = Math.sqrt((heroNodes[a].x - heroNodes[b].x) ** 2 + (heroNodes[a].y - heroNodes[b].y) ** 2);
-                        if (distance < heroConnectionDistance) {
-                            let opacity = 1 - (distance / heroConnectionDistance);
-                            heroCtx.strokeStyle = 'rgba(139, 174, 255, ' + opacity * 0.7 + ')';
-                            heroCtx.lineWidth = 1;
-                            heroCtx.beginPath();
-                            heroCtx.moveTo(heroNodes[a].x, heroNodes[a].y);
-                            heroCtx.lineTo(heroNodes[b].x, heroNodes[b].y);
-                            heroCtx.stroke();
-                        }
-                    }
-                }
-            }
-            let heroResizeTimer;
-            window.addEventListener('resize', () => {
-                clearTimeout(heroResizeTimer);
-                heroResizeTimer = setTimeout(() => {
-                    heroCanvas.width = heroCanvas.parentElement.offsetWidth;
-                    heroCanvas.height = heroCanvas.parentElement.offsetHeight;
-                    heroInit();
-                }, 250);
-            });
-            heroInit();
-            heroAnimate();
-        }
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js" defer></script>
+    <script src="js/hero-canvas.js" defer></script>
     <script>
         const nav = document.querySelector('.main-nav');
         const navToggle = document.querySelector('.mobile-nav-toggle');

--- a/public/js/hero-canvas.js
+++ b/public/js/hero-canvas.js
@@ -1,0 +1,107 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const canvas = document.getElementById('hero-canvas');
+  const hero = document.getElementById('hero');
+  if (!canvas || !hero) return;
+  const ctx = canvas.getContext('2d');
+  const particles = [];
+  const maxParticles = window.matchMedia('(max-width: 768px)').matches ? 80 : 200;
+  const spawnCount = window.matchMedia('(pointer: coarse)').matches ? 2 : 5;
+  let dpr = window.devicePixelRatio || 1;
+
+  const useThree = typeof THREE !== 'undefined';
+  let camera;
+  if (useThree) {
+    camera = new THREE.PerspectiveCamera(60, canvas.clientWidth / canvas.clientHeight, 0.1, 1000);
+    camera.position.z = 400;
+  }
+
+  function resize() {
+    dpr = window.devicePixelRatio || 1;
+    const { clientWidth, clientHeight } = canvas;
+    canvas.width = clientWidth * dpr;
+    canvas.height = clientHeight * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    if (useThree) {
+      camera.aspect = clientWidth / clientHeight;
+      camera.updateProjectionMatrix();
+    }
+  }
+  resize();
+  window.addEventListener('resize', resize);
+
+  function addParticles(x, y) {
+    for (let i = 0; i < spawnCount; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = Math.random() * 1.5 + 0.5;
+      const life = 60 + Math.random() * 40;
+      const p = {
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life,
+        maxLife: life,
+        size: 2 + Math.random() * 3,
+        startHue: 200 + Math.random() * 20,
+        endHue: 260 + Math.random() * 20
+      };
+      if (useThree) {
+        p.z = Math.random() * 200 - 100;
+        p.vz = Math.random() * 0.5 - 0.25;
+        p.vector = new THREE.Vector3(x - canvas.clientWidth / 2, y - canvas.clientHeight / 2, p.z);
+      }
+      particles.push(p);
+    }
+    while (particles.length > maxParticles) particles.shift();
+  }
+
+  function pointerMove(e) {
+    const rect = hero.getBoundingClientRect();
+    const x = (e.clientX ?? e.touches[0].clientX) - rect.left;
+    const y = (e.clientY ?? e.touches[0].clientY) - rect.top;
+    addParticles(x, y);
+  }
+
+  hero.addEventListener('mousemove', pointerMove);
+  hero.addEventListener('touchmove', pointerMove, { passive: true });
+
+  // spawn a few particles initially so the effect is visible
+  addParticles(canvas.clientWidth / 2, canvas.clientHeight / 2);
+
+  function animate() {
+    ctx.clearRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+    for (let i = particles.length - 1; i >= 0; i--) {
+      const p = particles[i];
+      p.life--;
+      if (p.life <= 0) {
+        particles.splice(i, 1);
+        continue;
+      }
+      p.x += p.vx;
+      p.y += p.vy;
+
+      let drawX = p.x;
+      let drawY = p.y;
+      let scale = 1;
+      if (useThree) {
+        p.z += p.vz;
+        p.vector.set(p.x - canvas.clientWidth / 2, p.y - canvas.clientHeight / 2, p.z);
+        const projected = p.vector.clone().project(camera);
+        drawX = (projected.x * 0.5 + 0.5) * canvas.clientWidth;
+        drawY = (-projected.y * 0.5 + 0.5) * canvas.clientHeight;
+        scale = Math.max(0.1, 1 - p.z / 400);
+      }
+
+      const t = 1 - p.life / p.maxLife;
+      const hue = p.startHue + (p.endHue - p.startHue) * t;
+      const alpha = 1 - t;
+      ctx.fillStyle = `hsla(${hue}, 80%, 60%, ${alpha})`;
+
+      ctx.beginPath();
+      ctx.arc(drawX, drawY, p.size * scale, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    requestAnimationFrame(animate);
+  }
+  animate();
+});


### PR DESCRIPTION
## Summary
- keep hero section at top and emit particles from mouse/touch over the entire hero area
- move "Problem" block below hero and add sliding, delayed line animations
- spawn initial particles and slide-in effect to avoid missing visuals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953b2b66ec832ab48e96997a632531