### PR TITLE
Animate problem section lines with keyframe effects

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,7 +2,7 @@
 /* Problem-Abschnitt   */
 /* ------------------- */
 .problem-section {
-    background-color: var(--bg-color);
+    background: linear-gradient(135deg, #0A1931 0%, #112240 100%);
     padding: 100px 20px;
     text-align: center;
     font-size: 1.5rem;
@@ -12,14 +12,23 @@
 
 .problem-line {
     opacity: 0;
-    transform: translateY(20px);
-    transition: opacity 0.8s ease, transform 0.8s ease;
+    transform: translateY(20px) scale(0.95);
     margin-bottom: 20px;
 }
 
+@keyframes problemLineIn {
+    0% {
+        opacity: 0;
+        transform: translateY(20px) scale(0.95);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
 .problem-line.show {
-    opacity: 1;
-    transform: translateY(0);
+    animation: problemLineIn 1s ease forwards;
 }
 
 .problem-line.highlight {

--- a/public/index.html
+++ b/public/index.html
@@ -128,7 +128,7 @@
                 if (entry.isIntersecting) {
                     setTimeout(() => {
                         entry.target.classList.add("show");
-                    }, index * 200);
+                    }, index * 300);
                     observer.unobserve(entry.target);
                 }
             });


### PR DESCRIPTION
## Summary
- Add a linear gradient background to the problem section for visual depth.
- Replace transition-based reveal with keyframe animation combining opacity, translateY and scale.
- Adjust IntersectionObserver timeout to match the longer animation duration.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896276e9c48832a8d62897923996b18