### PR TITLE
Add heading for problem section

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -10,6 +10,10 @@
     line-height: 1.6;
 }
 
+.problem-section h2 {
+    margin-bottom: 40px;
+}
+
 .problem-line {
     opacity: 0;
     transform: translateY(20px);

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,7 @@
         </section>
         <!-- Problem-Abschnitt -->
         <section id="problem" class="problem-section">
+            <h2>Die aktuellen Herausforderungen</h2>
             <div class="problem-line">Fachkräfte? Kaum zu finden – und schwer zu halten.</div>
             <div class="problem-line">Wissen? Geht in Rente und verschwindet.</div>
             <div class="problem-line">Bürokratie? Frisst jeden Tag mehr Zeit.</div>


### PR DESCRIPTION
## Summary
- add a descriptive heading above the problem lines on the home page
- style the problem section heading with custom margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896276dc87c832ab559978ee2f5e28b